### PR TITLE
chore: Release v2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-atlassian",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-atlassian",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-atlassian",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "MCP server for Atlassian (Confluence and Jira) integration",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Release v2.1.0

This PR bumps the version to 2.1.0 for the npm release.

### What's included:
- Tool usability improvements (14 tools renamed for clarity)
- Enhanced tool descriptions with usage guidance
- Security and logging improvements
- Comprehensive test coverage
- All tests passing (357 tests)

### After merge:
The publish workflow will automatically publish to npm using the configured NPM_TOKEN.