### PR TITLE
fix: include generated declaration files in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 # Source files
 src/
 *.ts
-\!*.d.ts
+!*.d.ts
 
 # Test files
 **/__tests__/
@@ -13,7 +13,7 @@ coverage/
 # Development files
 .env
 .env.*
-\!.env.example
+!.env.example
 *.log
 npm-debug.log*
 
@@ -33,8 +33,8 @@ npm-debug.log*
 # Documentation source
 docs/
 *.md
-\!README.md
-\!LICENSE
+!README.md
+!LICENSE
 
 # Build files
 tsconfig.json

--- a/.npmignore
+++ b/.npmignore
@@ -52,4 +52,3 @@ node_modules/
 tmp/
 temp/
 CODEOWNERS
-EOF < /dev/null


### PR DESCRIPTION
# fix: include generated declaration files in package

## Summary

- Fix `.npmignore` negation patterns so emitted `.d.ts` files are included in packed releases.
- Keep existing build and package metadata unchanged.

## Why

The published `mcp-atlassian@2.1.0` package advertises `./dist/index.d.ts` via `types`, but the npm tarball omits all `.d.ts` files while still including `.d.ts.map` files. As a result, strict TypeScript consumers get TS7016 when importing the package.

The repo already enables `declaration` and `declarationMap` in `tsconfig.json`; the issue is that `.npmignore` currently uses escaped negation patterns such as `\!*.d.ts`. Those do not re-include declarations after the broader `*.ts` ignore pattern.

## Verification

- `npm run build`
- `npm pack --dry-run --json`
- `git diff --check`
- Confirmed the dry-run tarball includes `dist/index.d.ts`
- Confirmed the dry-run tarball includes 22 `.d.ts` files and 22 `.d.ts.map` files

Note: `git diff --check` passed with a CRLF warning only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the npm package configuration to adjust which exception files are included, ensuring TypeScript declaration files, documentation, and license information are packaged as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->